### PR TITLE
Fix https://intel-hpdd.github.io/Online-Help/

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,1 @@
 theme: jekyll-theme-cayman
-destination: dist
-baseurl: "/help"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.3",
   "description": "The IML help docs",
   "scripts": {
-    "build": "rm -rf dist && bundle exec jekyll build",
+    "build": "rm -rf dist && bundle exec jekyll build --destination dist --baseurl '/help'",
     "start": "bundle exec jekyll serve",
     "postversion": "npm run build"
   },


### PR DESCRIPTION
- reset config properties in _config.yml as it is affecting  
https://intel-hpdd.github.io/Online-Help/
- Define baseurl and destination as arguments to the build script