### PR TITLE
- Remove all references to centOS 7.3 as we only support 7.4

### DIFF
--- a/docs/Config_and_using_HSM_6_0.md
+++ b/docs/Config_and_using_HSM_6_0.md
@@ -100,6 +100,20 @@ As soon as copytool services are requested, the copytool worker will respond. Se
 
 After configuring the Copytool Agent node and adding Copytool to that agent, you can use HSM to manage file archiving, free-up file system storage, and improve overall file system performance. 
 
+1. Bind the Lustre* file system to an HSM coordinator. Run the following command on the MDS node:
+
+    ```
+    $ lctl set_param mdt.<$FSNAME>-MDT0000.hsm_control=enabled
+    mdt.lustre-MDT0000.hsm_control=enabled
+    ```
+
+1. Verify that the coordinator is running:
+
+    ```
+    $ lctl get_param mdt.<$FSNAME>-MDT0000.hsm_control
+    mdt.lustre-MDT0000.hsm_control=enabled
+    ```
+
 1. To use HSM, log into a regular Lustre* client node as the system superuser. The node is a compute client node not managed by Intel® Manager for Lustre* software. 
 1. Issue `lfs` commands to initiate HSM actions (archive, restore, release, remove). 
     

--- a/docs/Contributor_Docs/cd_Setting_Up_Clients.md
+++ b/docs/Contributor_Docs/cd_Setting_Up_Clients.md
@@ -6,7 +6,7 @@ In your vagrant folder, run the following script to prepare both client c1 and c
 ```
 vagrant sh -c '\
 sudo yum-config-manager --add-repo https://downloads.hpdd.intel.com/public/lustre/lustre-2.10.1/el7/client/&& \
-ed <<EOF /etc/yum.repos.d/downloads.hpdd.intel.com_public_lustre_lustre-2.10.1_el7_client_.repo
+sudo ed <<EOF /etc/yum.repos.d/downloads.hpdd.intel.com_public_lustre_lustre-2.10.1_el7_client_.repo
 /enabled/a
 gpgcheck=0
 gpgkey=http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-7

--- a/docs/Contributor_Docs/cd_UnInstall_IML.md
+++ b/docs/Contributor_Docs/cd_UnInstall_IML.md
@@ -90,7 +90,7 @@ service chroma-agent stop
 
 ### Remove agent software
 ```
-yum remove chroma-agent chroma-agent-management chroma-diagnostics
+yum remove chroma-agent chroma-agent-management iml-diagnostics
 ```
 
 ### Unconfigure NTP

--- a/docs/Errors_Troubleshooting_12_0.md
+++ b/docs/Errors_Troubleshooting_12_0.md
@@ -240,71 +240,136 @@ manually fail the target over to the peer server. </td>
 
 ## <a id="12.2"></a>Running Intel® Manager for Lustre* software diagnostics
 
-If Intel® Manager for Lustre* software is not operating normally and you require support from Intel® customer support, you may be asked to run chroma-diagnostics on any servers that are suspected of having problems, and/or on the server hosting the Intel® Manager for Lustre* software dashboard. The results of running the diagnostics should be attached to the ticket you are filing describing the problem. These diagnostics are described next.
+If Intel® Manager for Lustre* software is not operating normally and you require support from Intel® customer support, you may be asked to run iml-diagnostics on any servers that are suspected of having problems, and/or on the server hosting the Intel® Manager for Lustre* software dashboard. The results of running the diagnostics should be attached to the ticket you are filing describing the problem. These diagnostics are described next.
 
 **Run diagnostics**
 
 1. Log into the server in question. Admin login is required in order to collect all desired data.
 1. Enter the following command at the prompt:
-```
-#chroma-diagnostics
-```
+    ```
+    #iml-diagnostics
+    ```
+
+    This command generates a compressed tar.xz file that you can email to Intel® customer support. The following are sample displayed results of running this command. (The resulting tar.xz file will have a different file name.)
 
 
-This command generates a compressed tar.lzma file that you can email to Intel® customer support. The following are sample displayed results of running this command. (The resulting tar.lzma file will have a different file name.)
+    ```
+    sosreport (version 3.4)
+
+    This command will collect diagnostic and configuration information from
+    this CentOS Linux system and installed applications.
+
+    An archive containing the collected information will be generated in
+    /var/tmp/sos.p3Djuo and may be provided to a CentOS support
+    representative.
+
+    Any information provided to CentOS will be treated in accordance with
+    the published support policies at:
+
+    https://wiki.centos.org/
+
+    The generated archive may contain data considered sensitive and its
+    content should be reviewed by the originating organization before being
+    passed to any third party.
+
+    No changes will be made to system configuration.
 
 
-```
-Collecting diagnostic files
+    Setting up archive ...
+    Setting up plugins ...
+    Running plugins. Please wait ...
 
-Detected devices
-Devices monitored
-Listed installed packages
-Listed cibadmin --query
-Listed: pcs config show
-Listed: crm_mon -1r
-Finger printed Intel® Manager for Lustre* software installation
-Listed running processes
-listed PCI devices
-listed file system disk space.
-listed cat /proc/cpuinfo
-listed cat /proc/meminfo
-listed cat /proc/mounts
-listed cat /proc/partitions
-Listed hosts
-Copied 1 log files.
-Compressing diagnostics into LZMA (archive)
+    Running 1/10: block...
+    Running 2/10: filesys...
+    Running 3/10: iml...
+    Running 4/10: kernel...
+    Running 5/10: logs...
+    Running 6/10: memory...
+    Running 7/10: pacemaker...
+    Running 8/10: pci...
+    Running 9/10: processor...
+    Running 10/10: yum...
 
-Diagnostic collection is completed.
-Size: 16K  /var/log/diagnostics_20150623T160338_lotus-4vm15.iml.intel.com.tar.lzma
+    Creating compressed archive...
 
-The diagnostic report tar.lzma file can be sent to Intel® Manager for Lustre* software Support for analysis.
-```
+    Your sosreport has been generated and saved in:
+    /var/tmp/sosreport-iml.dev-20171017003954.tar.xz
+
+    The checksum is: f018ba301df835862e559aa98465e9fc
+
+    Please send this file to your support representative.
+    ```
 
 You can also decompress the file and examine the results. To unpack and extract the files, use this command:
 
 ```
-tar --lzma -xvpf <file_name>.tar.lzma
+tar --xz -xvpf <file_name>.tar.xz
 ```
 
-**Help for chroma-diagnostics**
+**Help for iml-diagnostics**
 
 Generally, if requested you should run this command without options, as this will generate the needed data. Enter 
 ```
-chroma-diagnostics -h
+iml-diagnostics -h
 ```
+
  to see help for this command, as follows:
 
 ```
-# chroma-diagnostics -h
-usage: chroma-diagnostics [-h] [--verbose] [--days-back DAYS_BACK]
-Run this to save a tar-file collection of logs and diagnostic output.
-The tar-file created is compressed with lzma.
-Sample output: /var/log/diagnostics_<date>_<fqdn>.tar.lzma
-optional arguments:
- -h, --help   show this help message and exit
- --verbose, -v   More output for troubleshooting.
- --days-back DAYS_BACK, -d DAYS_BACK
-Number of days back to collect logs. default is 1. 0 would mean today's logs only.
+# iml-diagnostics -h
+Usage: sosreport [options]
+
+Options:
+  -h, --help            show this help message and exit
+  -l, --list-plugins    list plugins and available plugin options
+  -n NOPLUGINS, --skip-plugins=NOPLUGINS
+                        disable these plugins
+  --experimental        enable experimental plugins
+  -e ENABLEPLUGINS, --enable-plugins=ENABLEPLUGINS
+                        enable these plugins
+  -o ONLYPLUGINS, --only-plugins=ONLYPLUGINS
+                        enable these plugins only
+  -k PLUGOPTS, --plugin-option=PLUGOPTS
+                        plugin options in plugname.option=value format (see
+                        -l)
+  --log-size=LOG_SIZE   set a limit on the size of collected logs (in MiB)
+  -a, --alloptions      enable all options for loaded plugins
+  --all-logs            collect all available logs regardless of size
+  --batch               batch mode - do not prompt interactively
+  --build               preserve the temporary directory and do not package
+                        results
+  -v, --verbose         increase verbosity
+  --verify              perform data verification during collection
+  --quiet               only print fatal errors
+  --debug               enable interactive debugging using the python debugger
+  --ticket-number=CASE_ID
+                        specify ticket number
+  --case-id=CASE_ID     specify case identifier
+  -p PROFILES, --profile=PROFILES
+                        enable plugins selected by the given profiles
+  --list-profiles       display a list of available profiles and plugins that
+                        they include
+  --name=CUSTOMER_NAME  specify report name
+  --config-file=CONFIG_FILE
+                        specify alternate configuration file
+  --tmp-dir=TMP_DIR     specify alternate temporary directory
+  --no-report           disable HTML/XML reporting
+  -s SYSROOT, --sysroot=SYSROOT
+                        system root directory path (default='/')
+  -c CHROOT, --chroot=CHROOT
+                        chroot executed commands to SYSROOT [auto, always,
+                        never] (default=auto)
+  -z COMPRESSION_TYPE, --compression-type=COMPRESSION_TYPE
+                        compression technology to use [auto, gzip, bzip2, xz]
+                        (default=auto)
+
+Some examples:
+
+ enable dlm plugin only and collect dlm lockdumps:
+   # sosreport -o dlm -k dlm.lockdump
+
+ disable memory and samba plugins, turn off rpm -Va collection:
+   # sosreport -n memory,samba -k rpm.rpmva=off
 ```
+
 [Top of page](#12.0)

--- a/docs/Install_Guide/ig_ch_03_building.md
+++ b/docs/Install_Guide/ig_ch_03_building.md
@@ -153,7 +153,7 @@ security vulnerabilities in the Red Hat software.
 -   RAID 1 is a minimum recommendation. RAID 10 may be optimal for heavy
     workloads. Software RAID (MDRAID) disk discovery is not supported.
 
--   Red Hat Enterprise Linux or CentOS Linux, version 7.3 or 7.4 must be
+-   Red Hat Enterprise Linux or CentOS Linux, version 7.4 must be
     installed on all servers. All Lustre* servers should be running the
     same OS and version. CentOS must have access to the base
     repositories and update repositories. Red Hat must have the
@@ -205,7 +205,7 @@ requirements.
     Chapter 5, Determining Hardware Configuration Requirements and
     Formatting Options* for more information.
 
--   Red Hat Enterprise Linux or CentOS Linux version 7.3 or 7.4 must be
+-   Red Hat Enterprise Linux or CentOS Linux version 7.4 must be
     installed. All Lustre* servers should be running the same OS and
     version. CentOS must have access to the base repositories and update
     repositories. Red Hat must have the following channels registered
@@ -256,7 +256,7 @@ The object storage server (OSS) provides access to the object storage target(s) 
 
 Requirements for HA object storage servers and targets are as follows:
 
--   Red Hat Enterprise Linux or CentOS Linux version 7.3 or 7.4 must be installed. All Lustre* servers should be running the same OS and version. CentOS must have access to the base repositories and update repositories. Red Hat must have the following channels registered and enabled:
+-   Red Hat Enterprise Linux or CentOS Linux version 7.4 must be installed. All Lustre* servers should be running the same OS and version. CentOS must have access to the base repositories and update repositories. Red Hat must have the following channels registered and enabled:
     - rhel-x86\_64-server-supplementary-7
     - rhel-x86\_64-server-optional-7
     - rhel-x86\_64-server-ha-7

--- a/docs/Install_Guide/ig_ch_04_pre_install.md
+++ b/docs/Install_Guide/ig_ch_04_pre_install.md
@@ -61,7 +61,7 @@ servers with the correct, supported operating system. Then install
 Lustre* as described herein. *Any existing file system data will be
 lost*.
 
-1.  Red Hat Enterprise Linux or CentOS Linux version 7.3 or 7.4 must be
+1.  Red Hat Enterprise Linux or CentOS Linux version 7.4 must be
     installed. All servers should be running the same OS and version.
 
     -   Do **not** install CMAN (Cluster Manager) or other packages that use
@@ -161,7 +161,7 @@ Firewall Considerations
 -----------------------
 
 Intel® Manager for Lustre* software runs on
-servers running RHEL or CentOS, version 7.3 or 7.4. The *firewalled* package
+servers running RHEL or CentOS, version 7.4. The *firewalled* package
 needs to be installed and configured for *all file system servers
 before* installing Intel® Manager for Lustre* software. The Intel® Manager for 
 Lustre* software installation process will then modify the firewall

--- a/docs/Install_Guide/ig_ch_07_configure_clients.md
+++ b/docs/Install_Guide/ig_ch_07_configure_clients.md
@@ -20,7 +20,7 @@ Client Requirements
 --------------------
 
 Each file system client must be running Red Hat Enterprise Linux (RHEL)
-or CentOS Linux, version 7.3 or 7.4.
+or CentOS Linux, version 7.4.
 
 **Notes**:
 
@@ -42,10 +42,10 @@ The following Lustre* packages are installed on clients:
 |`lustre-client-modules-<ver>`|Lustre* module RPM for clients.|
 |`lustre-client-<ver>`|Lustre* utilities for clients.|
 
-**To configure a Lustre* client running RHEL or CentOS version 7.3 or 7.4,
+**To configure a Lustre* client running RHEL or CentOS version 7.4,
 perform these steps:**
 
-1.  For clients running RHEL or CentOS version 7.3 or 7.4, add a client
+1.  For clients running RHEL or CentOS version 7.4, add a client
     repository with the following command.
 
     ```

--- a/docs/Install_Guide/ig_ch_11_updating.md
+++ b/docs/Install_Guide/ig_ch_11_updating.md
@@ -3,6 +3,6 @@
 [**Software Installation Guide Table of Contents**](ig_TOC.md)
 
 Intel® Manager for Lustre* software release 4.0.0 runs on servers and
-clients running RHEL or CentOS, version 7.3 or 7.4. To update the OS, see the software
+clients running RHEL or CentOS, version 7.4. To update the OS, see the software
 documentation provided by the OS vendor. All Lustre* servers must be
 running the same OS and version.

--- a/docs/Install_Guide/ig_ch_15_appC_backup_recovery.md
+++ b/docs/Install_Guide/ig_ch_15_appC_backup_recovery.md
@@ -26,9 +26,9 @@
 
 **Note**: This appendix is outdated and in
 revision.  Procedures in this appendix were developed for servers
-running RHEL 6.7.  The process for servers running RHEL 7.3 and 7.4 is very
+running RHEL 6.7.  The process for servers running RHEL 7.4 is very
 similar, but *this appendix has not yet been revised or tested for RHEL
-7.3 and 7.4*.
+7.4*.
 
 Introduction
 ------------
@@ -168,10 +168,10 @@ Operating System
 
 **Note**: This appendix is outdated and in revision.  Procedures in this
 appendix were developed for servers running RHEL 6.7.  The process for
-servers running RHEL 7.3 and 7.4 is very similar, but this appendix has not yet
-been revised or tested for RHEL 7.3 and 7.4.
+servers running RHEL 7.4 is very similar, but this appendix has not yet
+been revised or tested for RHEL 7.4.
 
-Red Hat Enterprise Linux or CentOS Linux, version 7.3 or 7.4 must be
+Red Hat Enterprise Linux or CentOS Linux, version 7.4 must be
 installed on all Lustre* servers. The OS must be deployed in a consistent
 and repeatable manner. All servers should be running the same OS and
 version. For Red Hat Enterprise Linux and CentOS Linux, template-driven
@@ -508,18 +508,13 @@ the Intel® Manager for Lustre* software GUI.
 
     ```bash
     yum -y install --enablerepo=lustre,iml-agent,e2fsprogs \
-
     lustre \
-
-    kernel- 3.10.0-514.2.2.el7_lustre.x86\_64.rpm
+    kernel-3.10.0-514.2.2.el7_lustre.x86_64.rpm
 
     yum -y install --enablerepo=iml-agent \
-
     chroma-agent \
-
     chroma-agent-management \
-
-    chroma-diagnostics
+    iml-diagnostics
     ```
 
 1.  Restore the RSyslog configuration and NTP Configuration:

--- a/docs/Install_Guide/ig_ch_16_appD_getting_help.md
+++ b/docs/Install_Guide/ig_ch_16_appD_getting_help.md
@@ -6,18 +6,18 @@
 require support from your Intel® technical support representative, then
 to help expedite resolution of the problem, please do the following:
 
-1.  [Run chroma diagnostics](#run-chroma-diagnostics).
+1.  [Run iml diagnostics](#run-iml-diagnostics).
 
 2.  [Submit a ticket](#submit-a-ticket).
 
-Run chroma diagnostics
+Run iml diagnostics
 ----------------------
 
-Run chroma-diagnostics on any of the servers that you suspect may be
+Run iml-diagnostics on any of the servers that you suspect may be
 having problems, and on the server hosting the Intel® Manager for Lustre*
-software dashboard. Chroma-Diagnostics generates a compressed
-tar.lzma file that you should attach to your JIRA ticket.
-To run chroma-diagnostics:
+software dashboard. Iml-Diagnostics generates a compressed
+tar.xz file that you should attach to your JIRA ticket / github issue.
+To run iml-diagnostics:
 
 1.  Log into the server in question as Admin. Admin login is required in
     order to collect all desired data.
@@ -25,55 +25,80 @@ To run chroma-diagnostics:
 2.  Enter the following command at the prompt:
 
     ```
-# chroma-diagnostics
-```
-The following results are displayed after running this command. (The resulting tar.lzma file will have a different file name.)
-```
-Collecting diagnostic files
-Detected devices
-Devices monitored
-Listed installed packages
-Listed cibadmin --query
-Listed: pcs config show
-Listed: crm\_mon -1r
-Finger printed Intel® Manager for Lustre* software installation
-Listed running processes
-listed PCI devices
-listed file system disk space.
-listed cat /proc/cpuinfo
-listed cat /proc/meminfo
-listed cat /proc/mounts
-listed cat /proc/partitions
-Listed hosts
-Copied 1 log files.
-Compressing diagnostics into LZMA (archive)
-Diagnostic collection is completed.
-Size: 16K
-/var/log/diagnostics\_20151006T160338\_lotus-4vm15.iml.intel.com.tar.lzma
-```
+    # iml-diagnostics
+    ```
+
+    The following results are displayed after running this command. (The resulting tar.xz file will have a different file name.)
+
+    ```
+    sosreport (version 3.4)
+
+    This command will collect diagnostic and configuration information from
+    this CentOS Linux system and installed applications.
+
+    An archive containing the collected information will be generated in
+    /var/tmp/sos.p3Djuo and may be provided to a CentOS support
+    representative.
+
+    Any information provided to CentOS will be treated in accordance with
+    the published support policies at:
+
+    https://wiki.centos.org/
+
+    The generated archive may contain data considered sensitive and its
+    content should be reviewed by the originating organization before being
+    passed to any third party.
+
+    No changes will be made to system configuration.
+
+
+    Setting up archive ...
+    Setting up plugins ...
+    Running plugins. Please wait ...
+
+    Running 1/10: block...
+    Running 2/10: filesys...
+    Running 3/10: iml...
+    Running 4/10: kernel...
+    Running 5/10: logs...
+    Running 6/10: memory...
+    Running 7/10: pacemaker...
+    Running 8/10: pci...
+    Running 9/10: processor...
+    Running 10/10: yum...
+
+    Creating compressed archive...
+
+    Your sosreport has been generated and saved in:
+    /var/tmp/sosreport-iml.dev-20171017003954.tar.xz
+
+    The checksum is: f018ba301df835862e559aa98465e9fc
+
+    Please send this file to your support representative.
+    ```
 
 
 1.  You can also decompress the file and examine the results. To unpack
     and extract the files, use this command:
 
     ```
-# tar --lzma -xvpf <file_name>.tar.lzma
-```
+    # tar --xz -xvpf <file_name>.tar.xz
+    ```
 
 
 1.  If desired, the following command returns help for chroma
     diagnostics:
 
     ```
-# chroma-diagnostics -h
-```
+    # iml-diagnostics -h
+    ```
 
 
 Submit a ticket
 ---------------
 
 You can submit a ticket using the Jira issue tracking system. Attach the
-chroma diagnostics log report to the ticket.
+sos report to the ticket.
 
 1.  Log in to the Jira dashboard at:
     <https://jira.hpdd.intel.com/secure/Dashboard.jspa>

--- a/docs/Introduction_1_0.md
+++ b/docs/Introduction_1_0.md
@@ -190,7 +190,7 @@ Differentiated Storage Services (DSS) allows I/O data to be classified, sometime
 
 **Support for Intel® Omni-Path Architecture**
 
-Intel® Omni-Path fabric support is available for Intel® Manager for Lustre* software systems running RHEL 7.3.  (Intel® OPA driver support requires RHEL 7.1 or newer, and so is not available for RHEL 6.x based systems.)
+Intel® Omni-Path fabric support is available for Intel® Manager for Lustre* software systems running RHEL 7.4.  (Intel® OPA driver support requires RHEL 7.1 or newer, and so is not available for RHEL 6.x based systems.)
 
 **LNet Configuration**
 


### PR DESCRIPTION
- Replace all references of chroma-diagnostics with iml-diagnostics.
  Some of the wording and code snippets needed updating as well
- Add required missing instructions for HSM
- Fix a small bug in cd_Setting_Up_Clients.md