### PR TITLE
Update online-help path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME            := iml-online-help
-PACKAGE_VERSION := 2.4.0
+PACKAGE_VERSION := 2.4.1
 PACKAGE_RELEASE := 1
 
 BASEURL ?= $(PWD)/targetdir

--- a/iml-online-help.spec
+++ b/iml-online-help.spec
@@ -1,6 +1,9 @@
 %define base_name online-help
+%define managerdir /iml-manager/
+%define backcompatdir /usr/lib%{managerdir}
+
 Name:       iml-%{base_name}
-Version:    2.4.0
+Version:    2.4.1
 Release:    1%{?dist}
 Summary:    IML Online Help
 License:    MIT
@@ -22,16 +25,23 @@ This module is a static html website based on the online-help markdown docs. The
 %install
 rm -rf %{buildroot}
 
-mkdir -p %{buildroot}%{_libdir}/iml-manager/%{name}
-cp -a targetdir/. %{buildroot}%{_libdir}/iml-manager/%{name}/
+mkdir -p %{buildroot}%{_datadir}%{managerdir}%{name}
+cp -al targetdir/. %{buildroot}%{_datadir}%{managerdir}%{name}
+mkdir -p %{buildroot}%{backcompatdir}
+ln -s %{_datadir}%{managerdir}%{name} %{buildroot}%{backcompatdir}%{name}
 
 %clean
 rm -rf %{buildroot}
 
-%files 
-%{_libdir}/iml-manager/%{name}
+%files
+%{_datadir}
+%{backcompatdir}
 
 %changelog
+* Fri Mar 16 2018 Joe Grund <joe.grund@intel.com> - 2.4.1-1
+- Remove *.md files
+- Move deployment dir to datadir.
+
 * Wed Mar 14 2018 Joe Grund <joe.grund@intel.com> - 2.4.0-1
 - Add upgrade docs.
 - Add debugging rust section.

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@iml/online-help",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "The IML help docs",
   "files": ["targetdir/"],
   "scripts": {
     "build":
-      "rm -rf targetdir && bundle exec jekyll build --destination targetdir --baseurl='/help'",
+      "rm -rf targetdir && bundle exec jekyll build --destination targetdir --baseurl='/help' && find targetdir -name *.md -print0 | xargs -0 rm -f",
     "start": "bundle exec jekyll serve",
     "postversion": "npm run build",
     "link-check":


### PR DESCRIPTION
Online-Help 2.4.0 pointed at a dir which didn't correspond with nginx.

Update the path, we will update Nginx in a subsequent IML release.

Signed-off-by: Joe Grund <joe.grund@intel.com>