### PR TITLE
Add section on debugging nodejs in vagrant

### DIFF
--- a/docs/Contributor_Docs/cd_Debugging_Node_In_Vagrant.md
+++ b/docs/Contributor_Docs/cd_Debugging_Node_In_Vagrant.md
@@ -1,0 +1,30 @@
+# Debugging a Running Nodejs Process In Vagrant
+
+[**Software Contributor Documentation Table of Contents**](cd_TOC.md)
+
+There are some cases where you'd like to debug a running nodejs process
+running on a vagrant node.
+
+This guide will walk through that process.
+
+1.  Install `node-inspector` on the vagrant node.
+
+    ```bash
+    npm i -g node-inspector
+    ```
+
+1.  Put the process into debug mode by sending a `USR1` signal:
+
+    ```bash
+    systemctl kill -s SIGUSR1 SERVICE_NAME_HERE
+    ```
+
+1.  start `node-inspector`:
+
+    ```bash
+    node-inspector
+    ```
+
+1.  On the host, connect to `node-inspector` using the ip address the vagrant node is running on (likely 0.0.0.0) and the port node-inspector has started on (likely 8080) using chrome.
+
+1.  This should load the app in an old version of devtools and will halt the code at first execution.

--- a/docs/Contributor_Docs/cd_TOC.md
+++ b/docs/Contributor_Docs/cd_TOC.md
@@ -1,63 +1,67 @@
-# Intel® Manager for Lustre* software
-# **Software Contributor Documentation**
+# Intel® Manager for Lustre\* software
+
+## **Software Contributor Documentation**
 
 [**Help Docs Table of Contents**](../../README.md)
 
-## Table of Contents
+### Table of Contents
+
 ---
 
 ![gears](md_Graphics/gears_sm.jpg)
 
-1. [Introduction](cd_Introduction.md)
+1.  [Introduction](cd_Introduction.md)
 
-1. [IML Screen Shots](cd_Screen_Shots.md)
+1.  [IML Screen Shots](cd_Screen_Shots.md)
 
-1. [IML Distributed Architecture](cd_Distributed_Architecture.md)
+1.  [IML Distributed Architecture](cd_Distributed_Architecture.md)
 
-1. [IML Contributor Workflow](cd_Contributor_Workflow.md)
+1.  [IML Contributor Workflow](cd_Contributor_Workflow.md)
 
-1. [Building IML](cd_Building_IML.md)
+1.  [Building IML](cd_Building_IML.md)
 
-1. [How to Contribute to the **Frontend**](cd_Contribute_To_Frontend.md)
+1.  [How to Contribute to the **Frontend**](cd_Contribute_To_Frontend.md)
 
-1. [How to Contribute To the **Backend**](cd_Contribute_To_Backend.md)
+1.  [How to Contribute To the **Backend**](cd_Contribute_To_Backend.md)
 
-1. [How to Create **Frontend** Unit Tests](cd_Create_Frontend_Unit_Tests.md)
+1.  [How to Create **Frontend** Unit Tests](cd_Create_Frontend_Unit_Tests.md)
 
-1. [Running Unit Tests for intel-manager-for-lustre Repo ](cd_intel-manager-for-lustre_Unit_Testing.md)
+1.  [Running Unit Tests for intel-manager-for-lustre Repo ](cd_intel-manager-for-lustre_Unit_Testing.md)
 
-1. [Create a Cluster of Virtual Machines with Vagrant](https://github.com/intel-hpdd/Vagrantfiles/blob/master/README.md)
+1.  [Create a Cluster of Virtual Machines with Vagrant](https://github.com/intel-hpdd/Vagrantfiles/blob/master/README.md)
 
-1. [Install IML on a Vagrant Virtual Cluster](cd_Installing_IML_On_Vagrant.md)
+1.  [Install IML on a Vagrant Virtual Cluster](cd_Installing_IML_On_Vagrant.md)
 
-1. [How to Uninstall IML](cd_UnInstall_IML.md)
+1.  [How to Uninstall IML](cd_UnInstall_IML.md)
 
-1. [Running SSI Tests](cd_Running_SSI_Tests.md)
+1.  [Running SSI Tests](cd_Running_SSI_Tests.md)
 
-1. [Create a Sample Storage plugin](https://github.com/intel-hpdd/sample-storage-plugin)
+1.  [Create a Sample Storage plugin](https://github.com/intel-hpdd/sample-storage-plugin)
 
-1. [IML Lustre Target Sequence Diagrams](cd_Lustre_Target_Sequence_Diagrams.md)
+1.  [IML Lustre Target Sequence Diagrams](cd_Lustre_Target_Sequence_Diagrams.md)
 
-1. [Managing Import Export Sequences of zpools within ZFS HA](cd_Managing_Import_Export_Sequences_Of_Zpools_Within_Zfs_HA.md)
+1.  [Managing Import Export Sequences of zpools within ZFS HA](cd_Managing_Import_Export_Sequences_Of_Zpools_Within_Zfs_HA.md)
 
-1. [Create a Monitored only ZFS Filesystem on a Vagrant virtual cluster](cd_Monitored_Only_ZFS.md)
+1.  [Create a Monitored only ZFS Filesystem on a Vagrant virtual cluster](cd_Monitored_Only_ZFS.md)
 
-1. [Creating a Managed Lustre ZFS Filesystem on a Vagrant virtual cluster](cd_Managed_ZFS.md)
+1.  [Creating a Managed Lustre ZFS Filesystem on a Vagrant virtual cluster](cd_Managed_ZFS.md)
 
-1. [Setting up Lustre Clients](cd_Setting_Up_Clients.html)
+1.  [Setting up Lustre Clients](cd_Setting_Up_Clients.html)
 
-1. [Setup Power Control on a Vagrant virtual cluster](cd_Setting_Up_Power_Control.md)
+1.  [Setup Power Control on a Vagrant virtual cluster](cd_Setting_Up_Power_Control.md)
 
-1. [How to create offline repos for IML 4.0.0](cd_Create_Offline_Repos.md)
+1.  [How to create offline repos for IML 4.0.0](cd_Create_Offline_Repos.md)
 
-1. [How to debug rust tests](cd_Debugging_Rust_Tests.md)
+1.  [How to debug rust tests](cd_Debugging_Rust_Tests.md)
+
+1.  [How to debug a running nodejs process in vagrant](cd_Debugging_Node_In_Vagrant.md)
 
 ---
+
 ## Resources
 
-1. [Things to Learn](cd_Things_To_Learn.md)
+1.  [Things to Learn](cd_Things_To_Learn.md)
 
-1. [Git Reference](cd_Git_Reference.md)
+1.  [Git Reference](cd_Git_Reference.md)
 
-1. [NPM and Yarn](cd_NPM_And_Yarn.md)
-
+1.  [NPM and Yarn](cd_NPM_And_Yarn.md)


### PR DESCRIPTION
Add a section on debugging a running nodejs
process in Vagrant.

This is useful for stepping through problems
on a live node.

Signed-off-by: Joe Grund <joe.grund@intel.com>